### PR TITLE
Add some config to improve development consistency

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+; editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.scss]
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
This adds some config files to improve development consistency. 

The [`.editorconfig` file](https://editorconfig.org/) causes [supporting editors](https://editorconfig.org/#download) (or editors with an EditorConfig plugin installed) to automatically configure themselves to the defined settings. 

The [`.gitattributes` file](https://git-scm.com/docs/gitattributes#_end_of_line_conversion) configures Git to automatically convert the line endings in text files to `\n`. This prevents contributors that use Windows from accidentally committing `\r\n` line endings.