### PR TITLE
add an exit after an installer redirect, prevents script execution af…

### DIFF
--- a/csb-loader.php
+++ b/csb-loader.php
@@ -10,7 +10,7 @@
    Load things needed always
    ---------------------------------------------------------------------- */
 global $BASE_DIR, $BASE_URL, $adminFlag;
-if (stream_resolve_include_path("csb-settings.php") === false) { header ("Location: csb-installer/"); }
+if (stream_resolve_include_path("csb-settings.php") === false) { header ("Location: csb-installer/"); exit(); }
 require "csb-settings.php";
 $loader = TRUE;
 


### PR DESCRIPTION
…ter location header

This is a standard practice in a php world (https://stackoverflow.com/questions/3553698/php-should-i-call-exit-after-calling-location-header)

I've seen a bunch of real world bugs because of this