### PR TITLE
Fixed installer not being found if site not set up and access URL is not in root

### DIFF
--- a/csb/csb-loader.php
+++ b/csb/csb-loader.php
@@ -10,7 +10,30 @@
    Load things needed always
    ---------------------------------------------------------------------- */
 global $BASE_DIR, $BASE_URL, $adminFlag;
-if (stream_resolve_include_path("csb-settings.php") === false) { header ("Location: csb-installer/"); exit(); }
+
+if (stream_resolve_include_path("csb-settings.php") === false) {
+   
+   /**
+    * This part finds the installer path regardless of what the original request URL was.
+    * It does so by comparing the relative URI to the root on the file system,
+    * checking if the directory exists there, and going up one level if not until reaching the root.
+    */
+   
+   $CUR_REL_URI = $_SERVER['REQUEST_URI'];   // The current relative request url, for example /CSB7.0/csb/science/ if that's the relative url to the server root.
+   $ROOT = $_SERVER['DOCUMENT_ROOT'];        // The root of the server on the file system.
+   $arrReq = explode("/", $CUR_REL_URI);     // The relative url is now an array ["", "CSB7.0", "CSB", "science", ""]
+   while (count($arrReq) >= 2) {             // While the array is not empty
+      $TEST_PATH = join("/", $arrReq) . "csb-installer/";  // Test path is the relative path with "csb-installer/" tacked on in the end
+      if (is_dir($ROOT . $TEST_PATH)) {                    // If that exists
+         header ("Location: " . $TEST_PATH);               // Go to there
+         exit();
+      }  
+      echo $TEST_PATH . "<br>";                       // If the relative path doesn't exist, print it, then...
+      array_splice($arrReq, count($arrReq) - 2, 1);   // Remove the last part of the path by splicing the array
+   }                                                  // And try again
+   die("Failed to find installer in any of the tested paths above!");   // If you reached here, the array emptied out - meaning the path couldn't be found on the tree from the source address to the root.
+}
+
 require "csb-settings.php";
 $loader = TRUE;
 


### PR DESCRIPTION
Solves issue #55 

Finds the installer path regardless of what the original request URL was.  
Does so by comparing the relative URI to the root on the file system, checking if the directory exists there, and going up one level if not until reaching the root.

Tested against:
http://localhost:8080/CSB7.0/csb/science/
http://localhost:8080/CSB7.0/csb/

And also tested with the installer dir not existing.