### PR TITLE
Adding keyboard shortcuts for app interface

### DIFF
--- a/csb/csb-content/js/AppInterface.js
+++ b/csb/csb-content/js/AppInterface.js
@@ -1,3 +1,26 @@
+const APP_HOTKEYS = {
+    1: 'circle-button',
+    2: 'eraser-button',
+    3: 'ejecta-button',
+    4: 'crater-chain-button',
+    5: 'boulder-button',
+    6: 'rock-button',
+    ' ': 'show-marks-toggle',
+};
+document.addEventListener('keydown', (event) => {
+    const ignores = ['INPUT', 'TEXTAREA', 'SELECT', 'OPTION', 'A', 'BUTTON'];
+
+    if (ignores.includes(event.target.tagName)) {
+        return;
+    }
+    const id = APP_HOTKEYS[event.key];
+    const element = id && document.getElementById(id);
+    if (element) {
+        event.preventDefault();
+        element.click();
+    }
+})
+
 function AppInterface(csbApp) {
     this.csbApp = csbApp;
 

--- a/csb/csb-content/js/AppInterface.js
+++ b/csb/csb-content/js/AppInterface.js
@@ -1,26 +1,3 @@
-const APP_HOTKEYS = {
-    1: 'circle-button',
-    2: 'eraser-button',
-    3: 'ejecta-button',
-    4: 'crater-chain-button',
-    5: 'boulder-button',
-    6: 'rock-button',
-    ' ': 'show-marks-toggle',
-};
-document.addEventListener('keydown', (event) => {
-    const ignores = ['INPUT', 'TEXTAREA', 'SELECT', 'OPTION', 'A', 'BUTTON'];
-
-    if (ignores.includes(event.target.tagName)) {
-        return;
-    }
-    const id = APP_HOTKEYS[event.key];
-    const element = id && document.getElementById(id);
-    if (element) {
-        event.preventDefault();
-        element.click();
-    }
-})
-
 function AppInterface(csbApp) {
     this.csbApp = csbApp;
 
@@ -443,20 +420,7 @@ function AppInterface(csbApp) {
                     self.showExample($("#app-example-" + $(this).attr('id')));
                     self.isHelpButtonEngaged = false;
                 } else {
-                    var tool = findToolFromButtonId($(this).attr('id'));
-                    if (tool.isActive) {
-                        if (tool.isToggleable) {
-                            tool.isToggledOn = !tool.isToggledOn;
-                            tool.onToggle(csbApp.appInterface);
-                            csbApp.needToRedrawCanvas = true;
-                        } else {
-                            self.selectedButton = $(this);
-                            self.selectedTool = tool;
-                            self.selectMark(null);
-                        }
-                        self.updateAllButtonAppearances();
-                    }
-                    self.displayExamples();
+                    self.clickTool($(this).attr('id'))
                 }
             }
         });
@@ -474,13 +438,54 @@ function AppInterface(csbApp) {
 
         this.updateAllButtonAppearances();
 
-        function findToolFromButtonId(htmlId) {
-            if (htmlId.indexOf("toggle") >= 0)
-                return csbApp.appInterface.tools[htmlId.slice(htmlId.indexOf("-") + 1)];
-            else
-                return csbApp.appInterface.tools[htmlId];
-        }
+        this.hotkeys = {
+            1: 'circle-button',
+            2: 'eraser-button',
+            3: 'ejecta-button',
+            4: 'crater-chain-button',
+            5: 'boulder-button',
+            6: 'rock-button',
+            ' ': 'show-marks-toggle',
+        };
+        document.addEventListener('keydown', this.keyPress.bind(this))
     };
+
+    this.keyPress = function(event) {
+        const ignores = ['INPUT', 'TEXTAREA', 'SELECT', 'OPTION', 'A', 'BUTTON'];
+
+        if (ignores.includes(event.target.tagName)) {
+          return;
+        }
+        const htmlId = this.hotkeys[event.key];
+        if (htmlId) {
+            event.preventDefault();
+            this.clickTool(htmlId);
+        }
+    }
+
+    this.findToolFromButtonId = function(htmlId) {
+        if (htmlId.indexOf("toggle") >= 0)
+            return csbApp.appInterface.tools[htmlId.slice(htmlId.indexOf("-") + 1)];
+        else
+            return csbApp.appInterface.tools[htmlId];
+    }
+
+    this.clickTool = function(htmlId) {
+        var tool = this.findToolFromButtonId(htmlId);
+        if (tool.isActive) {
+            if (tool.isToggleable) {
+                tool.isToggledOn = !tool.isToggledOn;
+                tool.onToggle(csbApp.appInterface);
+                csbApp.needToRedrawCanvas = true;
+            } else {
+                this.selectedButton = $('#'+htmlId);
+                this.selectedTool = tool;
+                this.selectMark(null);
+            }
+            this.updateAllButtonAppearances();
+        }
+        this.displayExamples();
+    }
 
     this.displayExamples = function () {
         var imageSet = null;


### PR DESCRIPTION
** Description **

I added keyboard shortcuts to the app because I wanted a faster way to delete craters and redraw them. 

** Fixed issue(s) **

Not an issue, just done on a whim.

** (optional) Notable changes **

* 1-6 will click any of the buttons and space will toggle show/hide. If approved I'll figure out a way to make them discover-able (probably by updating tutorial steps and the title text of the buttons).

* I had to elevate much of the code inside the click button function out into `AppInterface.clickTool` So that I could expose it to `AppInterface.keyPress`. 