### PR TITLE
Updated rescue text email.

### DIFF
--- a/csb/csb-accounts/auth-login.php
+++ b/csb/csb-accounts/auth-login.php
@@ -309,10 +309,10 @@ function regUser($db, $user, $pwhash)
     if ($result !== false) {
         foreach ($result as $role) {
             $roles[]= $role['role_id'];
-            
+
         }
     }
-    
+
     // Set sessions and cookie
     $_SESSION['user_id'] = $user['id'];
     setcookie('name', $user['username'], $timeout, "/");
@@ -350,6 +350,7 @@ function rescueUser ($db, $using, $value) {
     $rescue_link = $ACC_URL."rescue.php?go=".$to."&token=".$token;
 
 // TODO Add better INSTRUCTIONS_TO_CHANGE_MANUALLY
+// TODO Consider HTML formatting for the message body?
 
     $msg['subject'] = $SITE_NAME." CosmoQuest Password Reset";
 
@@ -357,8 +358,7 @@ function rescueUser ($db, $using, $value) {
 
     Someone has requested a password reset for your account.
 
-    If you made this request and would like to reset your password, please <a href='".$rescue_link."'>click here</a> or paste the link below into your browser.
-        ".$rescue_link."
+    If you made this request and would like to reset your password, please go to this link: ".$rescue_link."
 
     If you did not make this request, you may want to change your password by logging in with your username and password and INSTRUCTIONS_TO_CHANGE_MANUALLY.
 


### PR DESCRIPTION

** Description **
Continuing issue #91 : Body of email is plain text meaning HTML markup doesn't work.

** Fixed issue(s) **
Updated format of email body to not use HTML markup and made wording changes accordingly.

** TO-DO
Explore HTML format for message body. Will need to ensure that there's also a plain text version for simple email clients.