### PR TITLE
128-sass-deprecation-warnings

### DIFF
--- a/csb/csb-themes/default/sass/_card.scss
+++ b/csb/csb-themes/default/sass/_card.scss
@@ -43,7 +43,7 @@
 }
 
 .card-subtitle {
-  margin-top: -($card-spacer-y / 2);
+  margin-top: -(calc($card-spacer-y / 2));
   margin-bottom: 0;
 }
 
@@ -98,15 +98,15 @@
 //
 
 .card-header-tabs {
-  margin-right: -($card-spacer-x / 2);
+  margin-right: -(calc($card-spacer-x / 2));
   margin-bottom: -$card-spacer-y;
-  margin-left: -($card-spacer-x / 2);
+  margin-left: -(calc($card-spacer-x / 2));
   border-bottom: 0;
 }
 
 .card-header-pills {
-  margin-right: -($card-spacer-x / 2);
-  margin-left: -($card-spacer-x / 2);
+  margin-right: -(calc($card-spacer-x / 2));
+  margin-left: -(calc($card-spacer-x / 2));
 }
 
 // Card image

--- a/csb/csb-themes/default/sass/_carousel.scss
+++ b/csb/csb-themes/default/sass/_carousel.scss
@@ -185,9 +185,9 @@
 
 .carousel-caption {
   position: absolute;
-  right: ((100% - $carousel-caption-width) / 2);
+  right: calc((100% - $carousel-caption-width) / 2);
   bottom: 20px;
-  left: ((100% - $carousel-caption-width) / 2);
+  left: calc((100% - $carousel-caption-width) / 2);
   z-index: 10;
   padding-top: 20px;
   padding-bottom: 20px;

--- a/csb/csb-themes/default/sass/_custom-forms.scss
+++ b/csb/csb-themes/default/sass/_custom-forms.scss
@@ -62,7 +62,7 @@
   // Background-color and (when enabled) gradient
   &::before {
     position: absolute;
-    top: (($line-height-base - $custom-control-indicator-size) / 2);
+    top: calc(($line-height-base - $custom-control-indicator-size) / 2);
     left: 0;
     display: block;
     width: $custom-control-indicator-size;
@@ -77,7 +77,7 @@
   // Foreground (icon)
   &::after {
     position: absolute;
-    top: (($line-height-base - $custom-control-indicator-size) / 2);
+    top: calc(($line-height-base - $custom-control-indicator-size) / 2);
     left: 0;
     display: block;
     width: $custom-control-indicator-size;

--- a/csb/csb-themes/default/sass/_functions.scss
+++ b/csb/csb-themes/default/sass/_functions.scss
@@ -54,7 +54,7 @@
   $g: green($color);
   $b: blue($color);
 
-  $yiq: (($r * 299) + ($g * 587) + ($b * 114)) / 1000;
+  $yiq: calc((($r * 299) + ($g * 587) + ($b * 114)) / 1000);
 
   @if ($yiq >= $yiq-contrasted-threshold) {
     @return $yiq-text-dark;

--- a/csb/csb-themes/default/sass/_images.scss
+++ b/csb/csb-themes/default/sass/_images.scss
@@ -32,7 +32,7 @@
 }
 
 .figure-img {
-  margin-bottom: ($spacer / 2);
+  margin-bottom: calc($spacer / 2);
   line-height: 1;
 }
 

--- a/csb/csb-themes/default/sass/_jumbotron.scss
+++ b/csb/csb-themes/default/sass/_jumbotron.scss
@@ -1,5 +1,5 @@
 .jumbotron {
-  padding: $jumbotron-padding ($jumbotron-padding / 2);
+  padding: $jumbotron-padding calc($jumbotron-padding / 2);
   margin-bottom: $jumbotron-padding;
   background-color: $jumbotron-bg;
   @include border-radius($border-radius-lg);

--- a/csb/csb-themes/default/sass/_popover.scss
+++ b/csb/csb-themes/default/sass/_popover.scss
@@ -44,7 +44,7 @@
 
   .arrow::before,
   .arrow::after {
-    border-width: $popover-arrow-height ($popover-arrow-width / 2) 0;
+    border-width: $popover-arrow-height calc($popover-arrow-width / 2) 0;
   }
 
   .arrow::before {
@@ -70,7 +70,7 @@
 
   .arrow::before,
   .arrow::after {
-    border-width: ($popover-arrow-width / 2) $popover-arrow-height ($popover-arrow-width / 2) 0;
+    border-width: calc($popover-arrow-width / 2) $popover-arrow-height calc($popover-arrow-width / 2) 0;
   }
 
   .arrow::before {
@@ -93,7 +93,7 @@
 
   .arrow::before,
   .arrow::after {
-    border-width: 0 ($popover-arrow-width / 2) $popover-arrow-height ($popover-arrow-width / 2);
+    border-width: 0 calc($popover-arrow-width / 2) $popover-arrow-height calc($popover-arrow-width / 2);
   }
 
   .arrow::before {
@@ -113,7 +113,7 @@
     left: 50%;
     display: block;
     width: $popover-arrow-width;
-    margin-left: ($popover-arrow-width / -2);
+    margin-left: calc($popover-arrow-width / -2);
     content: "";
     border-bottom: $popover-border-width solid $popover-header-bg;
   }
@@ -131,7 +131,7 @@
 
   .arrow::before,
   .arrow::after {
-    border-width: ($popover-arrow-width / 2) 0 ($popover-arrow-width / 2) $popover-arrow-height;
+    border-width: calc($popover-arrow-width / 2) 0 calc($popover-arrow-width / 2) $popover-arrow-height;
   }
 
   .arrow::before {

--- a/csb/csb-themes/default/sass/_tooltip.scss
+++ b/csb/csb-themes/default/sass/_tooltip.scss
@@ -39,7 +39,7 @@
 
     &::before {
       top: 0;
-      border-width: $tooltip-arrow-height ($tooltip-arrow-width / 2) 0;
+      border-width: $tooltip-arrow-height calc($tooltip-arrow-width / 2) 0;
       border-top-color: $tooltip-arrow-color;
     }
   }
@@ -55,7 +55,7 @@
 
     &::before {
       right: 0;
-      border-width: ($tooltip-arrow-width / 2) $tooltip-arrow-height ($tooltip-arrow-width / 2) 0;
+      border-width: calc($tooltip-arrow-width / 2) $tooltip-arrow-height calc($tooltip-arrow-width / 2) 0;
       border-right-color: $tooltip-arrow-color;
     }
   }
@@ -69,7 +69,7 @@
 
     &::before {
       bottom: 0;
-      border-width: 0 ($tooltip-arrow-width / 2) $tooltip-arrow-height;
+      border-width: 0 calc($tooltip-arrow-width / 2) $tooltip-arrow-height;
       border-bottom-color: $tooltip-arrow-color;
     }
   }
@@ -85,7 +85,7 @@
 
     &::before {
       left: 0;
-      border-width: ($tooltip-arrow-width / 2) 0 ($tooltip-arrow-width / 2) $tooltip-arrow-height;
+      border-width: calc($tooltip-arrow-width / 2) 0 calc($tooltip-arrow-width / 2) $tooltip-arrow-height;
       border-left-color: $tooltip-arrow-color;
     }
   }

--- a/csb/csb-themes/default/sass/_variables.scss
+++ b/csb/csb-themes/default/sass/_variables.scss
@@ -443,7 +443,7 @@ $input-group-addon-border-color: $input-border-color !default;
 $custom-control-gutter: 1.5rem !default;
 $custom-control-spacer-x: 1rem !default;
 
-$custom-control-indicator-size: 1rem !default;
+$custom-control-indicator-size: 16px !default;
 $custom-control-indicator-bg: $gray-300 !default;
 $custom-control-indicator-bg-size: 50% 50% !default;
 $custom-control-indicator-box-shadow: inset 0 .25rem .25rem rgba($black, .1) !default;

--- a/csb/csb-themes/default/sass/_variables.scss
+++ b/csb/csb-themes/default/sass/_variables.scss
@@ -249,7 +249,7 @@ $h4-font-size: $font-size-base * 1.5 !default;
 $h5-font-size: $font-size-base * 1.25 !default;
 $h6-font-size: $font-size-base !default;
 
-$headings-margin-bottom: ($spacer / 2) !default;
+$headings-margin-bottom: calc($spacer / 2) !default;
 $headings-font-family: inherit !default;
 $headings-font-weight: 500 !default;
 $headings-line-height: 1.2 !default;
@@ -587,7 +587,7 @@ $nav-pills-link-active-bg: $component-active-bg !default;
 
 // Navbar
 
-$navbar-padding-y: ($spacer / 2) !default;
+$navbar-padding-y: calc($spacer / 2) !default;
 $navbar-padding-x: $spacer !default;
 
 $navbar-nav-link-padding-x: .5rem !default;
@@ -596,7 +596,7 @@ $navbar-brand-font-size: $font-size-lg !default;
 // Compute the navbar-brand padding-y so the navbar-brand will have the same height as navbar-text and nav-link
 $nav-link-height: ($font-size-base * $line-height-base + $nav-link-padding-y * 2) !default;
 $navbar-brand-height: $navbar-brand-font-size * $line-height-base !default;
-$navbar-brand-padding-y: ($nav-link-height - $navbar-brand-height) / 2 !default;
+$navbar-brand-padding-y: calc(($nav-link-height - $navbar-brand-height) / 2) !default;
 
 $navbar-toggler-padding-y: .25rem !default;
 $navbar-toggler-padding-x: .75rem !default;
@@ -666,7 +666,7 @@ $card-bg: $white !default;
 
 $card-img-overlay-padding: 1.25rem !default;
 
-$card-group-margin: ($grid-gutter-width / 2) !default;
+$card-group-margin: calc($grid-gutter-width / 2) !default;
 $card-deck-margin: $card-group-margin !default;
 
 $card-columns-count: 3 !default;

--- a/csb/csb-themes/default/sass/mixins/_grid-framework.scss
+++ b/csb/csb-themes/default/sass/mixins/_grid-framework.scss
@@ -9,8 +9,8 @@
     position: relative;
     width: 100%;
     min-height: 1px; // Prevent columns from collapsing when empty
-    padding-right: ($gutter / 2);
-    padding-left: ($gutter / 2);
+    padding-right: calc($gutter / 2);
+    padding-left: calc($gutter / 2);
   }
 
   @each $breakpoint in map-keys($breakpoints) {

--- a/csb/csb-themes/default/sass/mixins/_grid.scss
+++ b/csb/csb-themes/default/sass/mixins/_grid.scss
@@ -4,8 +4,8 @@
 
 @mixin make-container() {
   width: 100%;
-  padding-right: ($grid-gutter-width / 2);
-  padding-left: ($grid-gutter-width / 2);
+  padding-right: calc($grid-gutter-width / 2);
+  padding-left: calc($grid-gutter-width / 2);
   margin-right: auto;
   margin-left: auto;
 }
@@ -23,8 +23,8 @@
 @mixin make-row() {
   display: flex;
   flex-wrap: wrap;
-  margin-right: ($grid-gutter-width / -2);
-  margin-left: ($grid-gutter-width / -2);
+  margin-right: calc($grid-gutter-width / -2);
+  margin-left: calc($grid-gutter-width / -2);
 }
 
 @mixin make-col-ready() {
@@ -34,19 +34,19 @@
   // later on to override this initial width.
   width: 100%;
   min-height: 1px; // Prevent collapsing
-  padding-right: ($grid-gutter-width / 2);
-  padding-left: ($grid-gutter-width / 2);
+  padding-right: calc($grid-gutter-width / 2);
+  padding-left: calc($grid-gutter-width / 2);
 }
 
 @mixin make-col($size, $columns: $grid-columns) {
-  flex: 0 0 percentage($size / $columns);
+  flex: 0 0 percentage(calc($size / $columns));
   // Add a `max-width` to ensure content within each column does not blow out
   // the width of the column. Applies to IE10+ and Firefox. Chrome and Safari
   // do not appear to require this.
-  max-width: percentage($size / $columns);
+  max-width: percentage(calc($size / $columns));
 }
 
 @mixin make-col-offset($size, $columns: $grid-columns) {
-  $num: $size / $columns;
+  $num: calc($size / $columns);
   margin-left: if($num == 0, 0, percentage($num));
 }

--- a/csb/csb-themes/default/sass/mixins/_nav-divider.scss
+++ b/csb/csb-themes/default/sass/mixins/_nav-divider.scss
@@ -4,7 +4,7 @@
 
 @mixin nav-divider($color: #e5e5e5) {
   height: 0;
-  margin: ($spacer / 2) 0;
+  margin: calc($spacer / 2) 0;
   overflow: hidden;
   border-top: 1px solid $color;
 }

--- a/csb/csb-themes/default/sass/utilities/_embed.scss
+++ b/csb/csb-themes/default/sass/utilities/_embed.scss
@@ -29,24 +29,24 @@
 
 .embed-responsive-21by9 {
   &::before {
-    padding-top: percentage(9 / 21);
+    padding-top: percentage(calc(9 / 21));
   }
 }
 
 .embed-responsive-16by9 {
   &::before {
-    padding-top: percentage(9 / 16);
+    padding-top: percentage(calc(9 / 16));
   }
 }
 
 .embed-responsive-4by3 {
   &::before {
-    padding-top: percentage(3 / 4);
+    padding-top: percentage(calc(3 / 4));
   }
 }
 
 .embed-responsive-1by1 {
   &::before {
-    padding-top: percentage(1 / 1);
+    padding-top: percentage(calc(1 / 1));
   }
 }


### PR DESCRIPTION
** Description **
<!--
A description what you did in this pull request
-->* Wrapped calculations using ` / ` in `calc()`
* Also fixed a units incompatibility ("1.5 and 1rem are incompatible"): replaced the 1rem with 16px (_variables.sass:446)
 

NB: I had to do the work on my previous PR because the underlying fork was inadvertently deleted so it cancelled the pull request. I addressed *all* instances of `/` being used for division that were outside a `calc()`.

** Fixed issue(s) **
<!--
Which issue did you address in the pull request
-->Issue #128

** (optional) Notable changes **
<!--
If your PR changes how CSB works in a significant way, here's the place to tell us
-->
