### PR TITLE
Command line scripts to chop images

### DIFF
--- a/jobs/bulk_chop.php
+++ b/jobs/bulk_chop.php
@@ -1,0 +1,293 @@
+<?php
+/*
+ * bulk_chop.php
+ * This is intended for chopping large amounts of identical (!) images. Takes
+ * a zip file with any number of images and a single text file named chopconfig
+ * with the following information:
+ * application_id          The id of the application you are assigning the
+ *                         images to. You can get this from the project
+ *                         dashboard.
+  * TODO: Make sure the application id is displayed on the project dashboard ;)
+ * imagesize               The size for the chopped images
+ * hoverlap                Horizontal overlap in pixels
+ * voverlap                Vertical overlap in pixels
+ * The important thing is that the overlap values need to be chosen to result
+ * in usable output images. If you do bulkchop, the rule is:
+ * "Garbage in, garbage out!"
+ */
+
+
+$debug = false;
+
+/* There are more supported image formats (see imagetypes()) and in future,
+ * WEBP and AVIF might be interesting, but we'll start with the "safe" JPG
+ * and PNG and see where it takes us. When extending, please choose the
+ * array key to correspond with the value of the IMAGETYPE constant of the
+ * format. And if something breaks, this might have changed.
+ */
+$allowed_formats    =   array(2 => 'jpg',3 => 'png');
+
+// This is a cron job. Ensure it is only called from the command line
+if (substr(php_sapi_name(), 0, 3) !== 'cli') {
+    die ("This script can only be run from the command line");
+}
+
+// Check if there are sufficient arguments supplied
+if ($argc < 2) {
+    die ("Usage: php bulk_chop.php <source_zipfile>");
+}
+else {
+    if ($debug) {
+        print "Received " . $argc . " arguments \n";
+        var_dump($argv);
+    }
+}
+
+$csbdir=dirname(getcwd()). DIRECTORY_SEPARATOR ."csb" . DIRECTORY_SEPARATOR;
+
+if ($debug) { print "Working directory is $csbdir, loading configuration \n"; };
+
+// Require the config loader. Assuming the jobs folder exists next to csb!
+require_once $csbdir.'csb-loader.php';
+
+// Basic sanitizing and variable assignment
+$zipfile    =   preg_replace("/\/{2}|\.{2}|\\{2}/", '', $argv[1]);
+
+
+// Make sure we are getting passed a filename that points to a file
+if (file_exists($zipfile) === false) {
+    die ("File $zipfile does not exist");
+}
+
+
+$zip    =   new ZipArchive;
+// Try to open the file, will fail if not a zipfile
+$res    =   $zip->open($zipfile);
+if ($res === false) {
+    die ("Are you sure this is a zipfile?");
+}
+else {
+    //Now that we opened the sesame, let's extract the contents into a temporary directory
+    $fh_tempdir     =   tempdir();
+    // Make sure the directory ends in a directory separator
+    If (substr($fh_tempdir,-1) != DIRECTORY_SEPARATOR) {
+        $fh_tempdir .= DIRECTORY_SEPARATOR;
+    }
+    
+    $res            =   $zip->extractTo($fh_tempdir);
+    if ($res === false) {
+        die ("Could not extract zip file into temporary directory, giving up");
+    }
+    // We don't need to keep the source open, clean up before continuing
+    $zip->close();
+    // Maybe we should clean up?
+    //unlink($zipfile);
+    
+    // See if there is a configuration present
+    if (file_exists($fh_tempdir . "chopconfig") === false) {
+        // Clean up before exiting
+        cleanup();
+        die ("Could not read config, please check zipfile");
+    }
+    // We're expecting an ini-style chop config
+    $chopconfig     =   parse_ini_file($fh_tempdir . "chopconfig");
+    /* 
+     * The chop config should consist of four parameters:
+     * - application id
+     * - image size
+     * - horizontal overlap
+     * - vertical overlap
+     * If it doesn't, we shouldn't chop 
+     */
+    if (count($chopconfig) <> 4) {
+        if ($debug) {
+            print "Looks like the chopconfig is invalid";
+            var_dump($chopconfig);
+        }
+        // Clean up before exiting
+        cleanup();
+        die("Invalid chop configuration file");
+    }
+    else {
+        // check presence 
+        if (isset($chopconfig['application_id'])) {
+            //sanitize input
+            $application_id =   filter_var($chopconfig['application_id'], FILTER_SANITIZE_NUMBER_INT);
+        }
+        if (isset($chopconfig['image_size'])) {
+            //sanitize input
+            $image_size     =   filter_var($chopconfig['image_size'], FILTER_SANITIZE_NUMBER_INT);
+        }
+        if (isset($chopconfig['hoverlap'])) {
+            //sanitize input
+            $hoverlap       =   filter_var($chopconfig['hoverlap'], FILTER_SANITIZE_NUMBER_INT);
+        }
+        if (isset($chopconfig['voverlap'])) {
+            //sanitize input
+            $voverlap       =   filter_var($chopconfig['voverlap'], FILTER_SANITIZE_NUMBER_INT);
+        }
+        // Now, if all is set
+        if (isset($application_id) && isset($image_size) && isset($hoverlap) && isset($voverlap)) {
+            if ($debug) {
+                print "Looks like we are good to go :)\n";
+            }
+        }
+        else {
+            if ($debug) {
+                print "Looks like the chopconfig is invalid\n";
+                var_dump($chopconfig);
+            }
+            // Clean up before exiting
+            cleanup();
+            die ("Invalid configuration!");
+        }
+    }
+    
+    // Let's check the contents of the zip file whether the image size is equal
+    // before we write nonsense into the database
+    foreach (glob($fh_tempdir . "*.*") as $masterimage) {
+        // Now, test the images
+        list ($imagewidth, $imageheight, $imagetype, $imageattr)  = getimagesize($masterimage);
+        // Check if the file we're opening is a format we can deal with. If not, bug out.
+        if (!array_key_exists($imagetype, $allowed_formats)) {
+            // Clean up before exiting
+            cleanup();
+            die ("Unsupported file type $imagetype in zip archive");
+        }
+        if (isset($zipimagewidth) && isset($zipimageheight)) {
+            
+            if (!($imagewidth == $zipimagewidth) || !($imageheight == $zipimageheight)) {
+                // Clean up before exiting
+                cleanup();
+                die("Images in the zip file are not the same size; exiting");
+            }
+        }
+        else {
+            // This should only happen once
+            if (is_int($imagewidth) && is_int($imageheight))
+            $zipimagewidth  =   $imagewidth;
+            $zipimageheight =   $imageheight;
+        }
+    }
+    // If we came here, the images in the zip file should all be the same
+    // dimensions, and we also have a config. Let's chop!
+    if($debug) {
+        "Setup for chopping, images ready, calling imagechop.";
+    }
+    
+    foreach (glob($fh_tempdir . "*.*") as $masterimage) {
+        // Now, before we actually chop something, test it
+        if($debug) {
+            print "Executing php " . __DIR__ . DIRECTORY_SEPARATOR . "imagechop.php" . " $application_id $masterimage $image_size $hoverlap $voverlap \n";
+        }
+        exec( "php " . __DIR__ . DIRECTORY_SEPARATOR . "imagechop.php" . " $application_id $masterimage $image_size $hoverlap $voverlap");
+    }
+}
+
+// Finally, time to clean up
+cleanup();
+
+
+
+/**
+ * function tempdir
+ * source: https://stackoverflow.com/questions/1707801/making-a-temporary-dir-for-unpacking-a-zipfile-into
+ * Creates a random unique temporary directory, with specified parameters,
+ * that does not already exist (like tempnam(), but for dirs).
+ *
+ * Created dir will begin with the specified prefix, followed by random
+ * numbers.
+ *
+ * @link https://php.net/manual/en/function.tempname.php
+ *
+ * @param string|null $dir Base directory under which to create temp dir.
+ *     If null, the default system temp dir (sys_get_temp_dir()) will be
+ *     used.
+ * @param string $prefix String with which to prefix created dirs.
+ * @param int $mode Octal file permission mask for the newly-created dir.
+ *     Should begin with a 0.
+ * @param int $maxAttempts Maximum attempts before giving up (to prevent
+ *     endless loops).
+ * @return string|bool Full path to newly-created dir, or false on failure.
+ */
+function tempdir($dir = null, $prefix = 'tmp_', $mode = 0700, $maxAttempts = 1000)
+{
+    /* Use the system temp dir by default. */
+    if (is_null($dir))
+    {
+        $dir = sys_get_temp_dir();
+    }
+    
+    /* Trim trailing slashes from $dir. */
+    $dir = rtrim($dir, DIRECTORY_SEPARATOR);
+    
+    /* If we don't have permission to create a directory, fail, otherwise we will
+     * be stuck in an endless loop.
+     */
+    if (!is_dir($dir) || !is_writable($dir))
+    {
+        return false;
+    }
+    
+    /* Make sure characters in prefix are safe. */
+    if (strpbrk($prefix, '\\/:*?"<>|') !== false)
+    {
+        return false;
+    }
+    
+    /* Attempt to create a random directory until it works. Abort if we reach
+     * $maxAttempts. Something screwy could be happening with the filesystem
+     * and our loop could otherwise become endless.
+     */
+    $attempts = 0;
+    do
+    {
+        $path = sprintf('%s%s%s%s', $dir, DIRECTORY_SEPARATOR, $prefix, mt_rand(100000, mt_getrandmax()));
+    } while (
+        !mkdir($path, $mode) &&
+        $attempts++ < $maxAttempts
+        );
+    
+    return $path;
+}
+
+
+/*
+ * function deletedir
+ * @param string dirname The directory to delete
+ * @return bool success (or not)
+ */
+function deletedir($dirname) 
+{
+    if(is_dir($dirname)) {
+        // For all entries in the directory
+        foreach (glob($dirname . "*", GLOB_MARK) as $file) {
+            if (is_dir($file)) {
+                // Not expecting directories, but who knows what people will upload
+                deletedir($file);
+            }
+            else {
+                // delete the file
+                unlink($file);
+            }
+        }
+        // Clean up the rest after we're done
+        rmdir($dirname);
+        return true;
+    }
+    else {
+        //Don't work on files
+        return false;
+    }
+}
+
+function cleanup() 
+{
+    global $fh_tempdir;
+    // Clean up before exiting
+    $rt         =   deletedir($fh_tempdir);
+    if ($rt === false) {
+        print "Error deleting $fh_tempdir, please remove manually!\n";
+    }
+}
+?>

--- a/jobs/imagechop.php
+++ b/jobs/imagechop.php
@@ -1,0 +1,213 @@
+<?php
+/*
+ *  imagechop.php
+ *  Takes image source, image size in px, vertical overlap in px, horizontal
+ *  overlap in px and output folder. Outputs images according to those
+ *  parameters as well as insert the done images into the database afterwards.
+ *  This is intended for bulk chopping via upload.
+ *  @param int application_id
+ *  @param string imagesource
+ *  @param int imagesize
+ *  @param int voverlap
+ *  @param int hoverlap
+ *  @return bool success
+ */
+
+$debug = false;
+
+// This is a job script. Ensure it is only called from the command line
+if (substr(PHP_SAPI, 0, 3) !== 'cli') {
+    die ("This script can only be run from the command line");
+}
+
+// Check if there are sufficient arguments supplied
+if ($argc != 6) {
+    die ("Usage: php imagechop.php <application_id> <source_image> <subimagesize> <overlap-h> <overlap-v>");
+}
+else {
+    if ($debug) {
+        print "Received " . $argc . "arguments \n";
+        var_dump($argv);
+        print"\n-------------------------------\n";
+    }
+}
+
+$csbdir=dirname(getcwd()). DIRECTORY_SEPARATOR ."csb" . DIRECTORY_SEPARATOR;
+
+if ($debug) { print "Working directory is $csbdir, loading configuration \n"; };
+
+// Require the config loader. Assuming the cron folder exists next to csb!
+require_once $csbdir.'csb-loader.php';
+require_once $DB_class;
+
+$db_conn = new DB($db_servername, $db_username, $db_password, $db_name, $db_port);
+
+// Basic sanity checks and variable assignment
+$application_id =   filter_var($argv[1],FILTER_SANITIZE_NUMBER_INT);
+$imagesource    =   preg_replace("/\/{2}|\.{2}|\\{2}/", '', $argv[2]);
+$imagesize      =   filter_var($argv[3],FILTER_SANITIZE_NUMBER_INT);
+$hoverlap       =   filter_var($argv[4],FILTER_SANITIZE_NUMBER_INT);
+$voverlap       =   filter_var($argv[5],FILTER_SANITIZE_NUMBER_INT);
+$image_parts    =   pathinfo($imagesource);
+/* There are more supported image formats (see imagetypes()) and in future,
+ * WEBP and AVIF might be interesting, but we'll start with the "safe" JPG
+ * and PNG and see where it takes us. When extending, please choose the
+ * array key to correspond with the value of the IMAGETYPE constant of the
+ * format. And if something breaks, this might have changed.
+ */
+$allowed_formats    =   array(2 => 'jpg',3 => 'png');
+
+// Get image information. We only need the first three, which are all numeric.
+// The fourth is the "width" and "height" attributes that can be used in HTML.
+$img = getimagesize($imagesource);
+if ($img === false) {
+    die ("Error opening master image file\n");
+}
+
+$baseimagewidth     =   $img[0];
+$baseimageheight    =   $img[1];
+$baseimagetype      =   $img[2];
+$baseimageattr      =   $img[3];
+
+
+$curwidth       =   0;
+$curheight      =   0;
+
+// Get the application name
+$app_sql = "SELECT name from applications where id = ?";
+$app_params = array($application_id);
+$app_res = $db_conn->runQueryWhere($app_sql,"i",$app_params);
+if ($app_res === false) {
+    // If we couldn't find the application name, bug out with a server error
+    print "Could not find application name: " . mysqli_errno() . ": " . mysqli_error();
+    $db_conn->closeDB();
+    exit();
+}
+$application_name = $app_res[0]['name'];
+if ($debug) { print "Chopping images for application $application_name \n"; };
+
+// Initialize variables for the raw images
+$imagepart      =  'csb-apps' . DIRECTORY_SEPARATOR . $application_name;
+$imagebasedir   =   $BASE_DIR . $imagepart;
+$imagebaseurl   =   $BASE_URL . $imagepart;
+$imagefolder    =   $imagebasedir . DIRECTORY_SEPARATOR . "raw_images";
+
+// Initialize variables for the subimages
+$subimage       =   null;
+$subimagenumber =   1;
+$subimagefolder =   $imagebasedir . DIRECTORY_SEPARATOR ."sub_images";
+$subimagebase   =   $image_parts['filename'];
+$subimageext    =   strtolower($image_parts['extension']);
+
+// Check if the file we're opening is a format we can deal with. If not, bug out.
+if (!array_key_exists($baseimagetype, $allowed_formats)) {
+    die ("Not supported file type");
+}
+// Choose the function names for the format of the raw image.
+$imageload  = "imagecreatefrom" . $allowed_formats[$baseimagetype];
+$imagesave  = "image" . $allowed_formats[$baseimagetype];
+
+// Make sure our destination folders exist
+if (is_dir($imagefolder) === false) {
+    mkdir($imagefolder, 0777, true);
+}
+else {
+    if (is_writable($imagefolder) === false) {
+        die ("Raw image folder exists but is not writable!\n");
+    }
+}
+if (is_dir($subimagefolder) === false) {
+    mkdir($subimagefolder, 0777, true);
+}
+else {
+    if (is_writable($subimagefolder) === false) {
+        die ("Subimage folder exists but is not writable!\n");
+    }
+}
+
+// First, copy our raw image
+copy($imagesource, $imagefolder . DIRECTORY_SEPARATOR . basename($imagesource));
+
+// Database, round 2
+$db_conn = new DB($db_servername, $db_username, $db_password, $db_name, $db_port);
+
+// Before we chop, write the imageset
+$imageset_sql    =  "INSERT INTO image_sets (name, application_id, created_at, updated_at)" .
+    "VALUES (?, ?,now(),now())";
+$imageset_params =  array($subimagebase,$application_id);
+
+if($debug) {
+    print "Executing SQL: INSERT INTO image_sets (name, application_id, created_at, updated_at) " .
+        "VALUES ($subimagebase,$application_id, now(), now()) \n";
+}
+$imageset_res    =  $db_conn->insert($imageset_sql,"si",$imageset_params);
+if ($imageset_res === false) {
+    // If we couldn't insert, bug out with a server error
+    print "Could not insert imageset: " . mysqli_errno() . ": " . mysqli_error();
+    $db_conn->closeDB();
+    exit(1);
+}
+else {
+    // Get the imageset id
+    $imagesetid_sql =   'SELECT id from image_sets where name = "' . $subimagebase .'"';
+    $imagesetid_res =   $db_conn->runBaseQuery($imagesetid_sql);
+    if ($debug) {
+        print "\n--------------------\n";
+        print "Dumping result of imageset_id query: \n";
+        var_dump($imagesetid_res);
+    }
+    
+    if ($imagesetid_res===false) {
+        print "Could not get imageset id!";
+        $db_conn->closeDB();
+        exit(1);
+    }
+}
+$imagesetid     =   $imagesetid_res[0]['id'];
+
+// Walk over the image width, stepping forward the image width minus the overlap, from left to right and top to bottom.
+for ($curheight=0; $curheight <= $baseimageheight-$imagesize; $curheight = $curheight + ($imagesize - $voverlap)) {
+    for ($curwidth=0; $curwidth <= $baseimagewidth-$imagesize; $curwidth = $curwidth + ($imagesize - $hoverlap)) {
+        if($debug) { print "Chopping image $subimagenumber with x=$curwidth, y=$curheight, imagesize=$imagesize and overlap h=$hoverlap, v=$voverlap \n"; }
+        // Create a new image object from the base image
+        $baseimage    = $imageload($imagesource);
+        // assemble the imagename
+        $subimagename = $subimagebase. "_" . $subimagenumber .  "." . $subimageext;
+        // crop the image to the right format
+        $subimage     = imagecrop($baseimage,array(
+            'x' => $curwidth,
+            'y' => $curheight,
+            'width' => $imagesize,
+            'height' => $imagesize
+        ));
+        $subimagefqn  = $subimagefolder . DIRECTORY_SEPARATOR . $subimagename;
+        print "Calling $imagesave to save $subimagefqn \n";
+        // Write the image to the filesystem
+        $imagesave($subimage, $subimagefqn);
+        // store the filename in an array
+        
+        $subimageurl  = $imagebaseurl . DIRECTORY_SEPARATOR . "CHOPPEDIMAGES" . DIRECTORY_SEPARATOR . $subimagename;
+        $subimagedetail='{"x":' . $curheight .', "y":'.$curwidth.'}';
+        //For each subimage in the imageset, write an entry into the images table
+        $image_sql    = 'INSERT INTO images (image_set_id, application_id, name, file_location, details) VALUES (?,?,?,?,?)';
+        $image_params = array(
+            $imagesetid,
+            $application_id,
+            $subimagename,
+            $subimageurl,
+            $subimagedetail
+        );
+        $image_res    = $db_conn->insert($image_sql, "iisss", $image_params);
+        // Bug out if that fails
+        if ($image_res===false) {
+            print "Could not write image to db!";
+            $db_conn->closeDB();
+            exit();
+        }
+        
+        //Finally, increment the counter
+        $subimagenumber++;
+    }
+}
+
+?>

--- a/jobs/index.php
+++ b/jobs/index.php
@@ -1,0 +1,3 @@
+<?php 
+// Intentionally left empty
+?>


### PR DESCRIPTION
** Description **
These are two simple command line scripts to chop images, one that takes individual images and another that takes a zip files with a number of images and a file called "chopconfig" that contains the configuration how to chop the images. 

Still required are a way to calculate the overlap, generate the chopconfig file and possibly to set default image parameters for an application.
